### PR TITLE
Fda service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ group :development, :test do
   gem 'rspec'
   gem 'pry'
   gem 'capybara'
+  gem 'launchy'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     json (2.3.1)
+    launchy (2.5.0)
+      addressable (~> 2.7)
     method_source (1.0.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -69,6 +71,7 @@ DEPENDENCIES
   faraday
   figaro
   json
+  launchy
   pry
   rake
   rspec

--- a/app/controllers/mset_api_service_app.rb
+++ b/app/controllers/mset_api_service_app.rb
@@ -1,5 +1,9 @@
 class MsetApiService < Sinatra::Base
 
+  get '/med_search' do
+    brand_name_search(params[:medication_name])
+  end
+
   ## TEST CALLS
 
   get '/' do

--- a/app/controllers/mset_api_service_app.rb
+++ b/app/controllers/mset_api_service_app.rb
@@ -1,8 +1,13 @@
 class MsetApiService < Sinatra::Base
 
   get '/sym_search' do
+    # product_labeling: OPEN FDA SEARCH BY PRODUCT_NDC
     response = FdaService.new.symptom_search(params[:product_ndc])
     response.body
+
+    # product_labeling: ADVERSE_EVENTS ENDPOINT
+    # response = FdaService.new.adverse_reactions_table(params[:product_ndc])
+    # response.body
   end
 
   get '/med_search' do

--- a/app/controllers/mset_api_service_app.rb
+++ b/app/controllers/mset_api_service_app.rb
@@ -1,6 +1,10 @@
 class MsetApiService < Sinatra::Base
 
-  
+  get '/sym_search' do
+    response = FdaService.new.symptom_search(params[:product_ndc])
+    response.body
+  end
+
   get '/med_search' do
     response = FdaService.new.brand_name_search(params[:medication_name])
     response.body

--- a/app/controllers/mset_api_service_app.rb
+++ b/app/controllers/mset_api_service_app.rb
@@ -1,7 +1,8 @@
 class MsetApiService < Sinatra::Base
 
   get '/med_search' do
-    brand_name_search(params[:medication_name])
+    response = FdaService.new.brand_name_search(params[:medication_name])
+    response.body
   end
 
   ## TEST CALLS

--- a/app/controllers/mset_api_service_app.rb
+++ b/app/controllers/mset_api_service_app.rb
@@ -1,5 +1,6 @@
 class MsetApiService < Sinatra::Base
 
+  
   get '/med_search' do
     response = FdaService.new.brand_name_search(params[:medication_name])
     response.body
@@ -18,18 +19,4 @@ class MsetApiService < Sinatra::Base
   get '/test2' do
     params[:med_name]
   end
-
-  ## ACTUAL API CALLS
-
-  # get '/med_search' do
-  #   # this is just an example... need to fill in with actual search code.
-  #   # Then we can refactor later.
-  #
-  #   med_name = params[:med_name]
-  #
-  #   conn = Faraday.new('https://api.fda.gov/drug/ndc.json')
-  #   response = conn.get("?search=brand_name:#{med_name}")
-  #
-  #   JSON.parse(response.body, symbolize_names: true)
-  # end
 end

--- a/app/services/fda_service.rb
+++ b/app/services/fda_service.rb
@@ -1,8 +1,8 @@
 class FdaService
 
   def brand_name_search(params)
-    response = conn.get("drug/ndc.json?search=brand_name_base:#{params}&limit=10")
-    json_parse(response)[:results]
+    conn.get("drug/ndc.json?search=brand_name_base:#{params}&limit=10")
+    # json_parse(response)
   end
 
   private

--- a/app/services/fda_service.rb
+++ b/app/services/fda_service.rb
@@ -1,5 +1,9 @@
 class FdaService
 
+  def adverse_reactions_table(medication_name)
+    conn.get("drug/label.json?search=adverse_reactions:#{medication_name}")
+  end
+
   def symptom_search(product_ndc)
     conn.get("drug/label.json?search=openfda.product_ndc.exact:#{product_ndc}")
   end

--- a/app/services/fda_service.rb
+++ b/app/services/fda_service.rb
@@ -1,8 +1,11 @@
 class FdaService
 
-  def brand_name_search(params)
-    conn.get("drug/ndc.json?search=brand_name_base:#{params}&limit=10")
-    # json_parse(response)
+  def symptom_search(product_ndc)
+    conn.get("drug/label.json?search=openfda.product_ndc.exact:#{product_ndc}")
+  end
+
+  def brand_name_search(medication_name)
+    conn.get("drug/ndc.json?search=brand_name_base:#{medication_name}&limit=10")
   end
 
   private

--- a/app/services/fda_service.rb
+++ b/app/services/fda_service.rb
@@ -10,10 +10,6 @@ class FdaService
 
   private
 
-  def json_parse(response)
-    JSON.parse(response.body, symbolize_names: true)
-  end
-
   def conn
     Faraday.new('https://api.fda.gov/')
   end

--- a/app/services/fda_service.rb
+++ b/app/services/fda_service.rb
@@ -1,0 +1,17 @@
+class FdaService
+
+  def brand_name_search(params)
+    response = conn.get("drug/ndc.json?search=brand_name_base:#{params}&limit=10")
+    json_parse(response)[:results]
+  end
+
+  private
+
+  def json_parse(response)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def conn
+    Faraday.new('https://api.fda.gov/')
+  end
+end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -12,6 +12,9 @@ Dir.glob(File.join(APP_ROOT, 'app', 'controllers', '*.rb')).each { |file| requir
 # require the model(s)
 Dir.glob(File.join(APP_ROOT, 'app', 'models', '*.rb')).each { |file| require file }
 
+# require the service(s)
+Dir.glob(File.join(APP_ROOT, 'app', 'services', '*.rb')).each { |file| require file }
+
 # require database configurations (we have none)
 # require File.join(APP_ROOT, 'config', 'database')
 

--- a/spec/requests/med_search_spec.rb
+++ b/spec/requests/med_search_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe 'med_search', type: :request do
+
+  def app
+    Sinatra::Application
+  end
+
+  xit 'can search fda api for medications by name' do
+    params = 'Adderall'
+    get "/med_search?medication_name=#{params}"
+    # how does testing work in here?? Can't get a response.
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -104,4 +104,5 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
   config.include Capybara::DSL
+  config.include Rack::Test::Methods
 end


### PR DESCRIPTION
This PR contains the working FDA API endpoints that the RAILS app will be using. 
Rails app no longer has the actual FDA API connections. 
Must merge this PR so that it gets pushed live to heroku. 

When developing in the RAILs app, I recommend using local server to launch SINATRA so you can play with it and adjust vs. using the live heroku connection. 

You can choose which connection to use in the RAILS app under `services/mset_service.rb`

@rrabinovitch @michaeljevans @ejdelsztejn 