### PR TITLE
Delete old setup test routes

### DIFF
--- a/app/controllers/mset_api_service_app.rb
+++ b/app/controllers/mset_api_service_app.rb
@@ -14,18 +14,4 @@ class MsetApiService < Sinatra::Base
     response = FdaService.new.brand_name_search(params[:medication_name])
     response.body
   end
-
-  ## TEST CALLS
-
-  get '/' do
-    "HOME"
-  end
-
-  get '/test' do
-    "Hello World"
-  end
-
-  get '/test2' do
-    params[:med_name]
-  end
 end

--- a/spec/requests/test_spec.rb
+++ b/spec/requests/test_spec.rb
@@ -1,6 +1,0 @@
-RSpec.describe 'test specs' do
-  it 'can run tests' do
-    visit '/test'
-    expect(current_path).to eq('/test')
-  end
-end


### PR DESCRIPTION
Getting rid of some old routes that were set up when I first created the app to make sure it could connect to Rails.